### PR TITLE
Fix: make problematic snippets produce valid syntax

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,25 +21,25 @@ fn format_with_rules(s: &str, rules: &[Box<dyn Rule>]) -> String {
     info!("formats text : {s:?}; with rules {:?}", rules);
     info!("parsed : \n{init:?}\n");
     let mut result = String::with_capacity(1024);
-
-    let mut parents: Vec<LinkedNode> = vec![root];
-
     let mut writer = Writer::default(&mut result);
-    while !parents.is_empty() {
-        let node = parents.pop().unwrap();
-        let mut children = node.children().collect_vec();
-        children.reverse();
-        parents.append(&mut children);
 
-        writer = writer.with_value(node.text().to_string());
-        for rule in rules.iter().filter(|&r| r.accept(&node)) {
-            //writer simulate node text
-            debug!("MATCHED RULE {rule:?}");
-            debug!("RULE FROM `{:?}`", writer.value());
-            rule.eat(writer.take(), &node, &mut writer);
-            debug!("RULE TO `{:?}`", writer.value());
-        }
-        writer.flush();
-    }
+    format_node(root, &mut writer, rules);
     result
+}
+
+fn format_node(node: LinkedNode, mut writer: &mut Writer, rules: &[Box<dyn Rule>]) {
+    for child in node.children() {
+        format_node(child, &mut writer, rules)
+    }
+    writer.set_value(node.text().to_string());
+    // TODO: this visits this node after the children, may need a way to tell the filter this is
+    // after, and have an option to process before the children
+    for rule in rules.iter().filter(|&r| r.accept(&node)) {
+        //writer simulate node text
+        debug!("MATCHED RULE {rule:?}");
+        debug!("RULE FROM `{:?}`", writer.value());
+        rule.eat(writer.take(), &node, &mut writer);
+        debug!("RULE TO `{:?}`", writer.value());
+    }
+    writer.flush();
 }

--- a/src/rules/tests/ident_item_func.rs
+++ b/src/rules/tests/ident_item_func.rs
@@ -2,7 +2,6 @@ use super::*;
 
 test_snippet!(
     no_apply_if_not_in_code_block,
-    ignore = "unimplemented",
     expect = "#f()",
     "#f()",
     &[IdentItemFunc.as_dyn()]
@@ -10,7 +9,6 @@ test_snippet!(
 
 test_snippet!(
     no_change_if_no_args,
-    ignore = "unimplemented",
     expect = "#{f()}",
     "#{f()}",
     &[IdentItemFunc.as_dyn()]

--- a/src/rules/tests/typst_format.rs
+++ b/src/rules/tests/typst_format.rs
@@ -3,8 +3,22 @@ use super::*;
 mod eof;
 
 test_snippet!(
-    later,
-    ignore = "need to treat fn first",
+    simple,
+    expect = "#tablex()",
+    "#tablex()",
+    rules().as_slice()
+);
+
+test_snippet!(
+    func_content,
+    expect = "#a()[]",
+    "#a()[]",
+    rules().as_slice()
+);
+
+test_snippet!(
+    space_for_newline,
+    ignore = "need block enter indentation",
     expect = "#{\n    a()[]\n}",
     "#{\na()[]\n}",
     rules().as_slice()

--- a/src/rules/tests/typst_format.rs
+++ b/src/rules/tests/typst_format.rs
@@ -31,6 +31,20 @@ test_snippet!(
 );
 
 test_snippet!(
+    comma_addition,
+    expect = "#set text(\n    font: \"Liberation Serif\",\n    lang: \"en\",\n)",
+    "#set text(font:\"Liberation Serif\",lang:\"en\")",
+    rules().as_slice()
+);
+
+test_snippet!(
+    comma_addition_simple,
+    expect = "#text(\n    lang: \"en\",\n)",
+    "#text(lang:\"en\")",
+    rules().as_slice()
+);
+
+test_snippet!(
     space_for_newline,
     ignore = "need block enter indentation",
     expect = "#{\n    a()[]\n}",

--- a/src/rules/tests/typst_format.rs
+++ b/src/rules/tests/typst_format.rs
@@ -10,9 +10,23 @@ test_snippet!(
 );
 
 test_snippet!(
-    func_content,
+    func_content_in,
+    expect = "#a([])",
+    "#a([])",
+    rules().as_slice()
+);
+
+test_snippet!(
+    func_content_after,
     expect = "#a()[]",
     "#a()[]",
+    rules().as_slice()
+);
+
+test_snippet!(
+    func_content_both,
+    expect = "#a([])[]",
+    "#a([])[]",
     rules().as_slice()
 );
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -42,7 +42,7 @@ impl<'a> Writer<'a> {
         self
     }
 
-    pub fn with_value(mut self, s: impl Into<String>) -> Self {
+    pub fn set_value(&mut self, s: impl Into<String>) -> &mut Self {
         self.value = s.into();
         self
     }
@@ -178,9 +178,8 @@ mod tests {
     #[test]
     fn creation() {
         let mut res = String::from("");
-        let writer = Writer::default(&mut res)
-            .with_value("Hello")
-            .with_style(Style { indent: 2 });
+        let mut writer = Writer::default(&mut res).with_style(Style { indent: 2 });
+        writer.set_value("Hello");
         similar_asserts::assert_eq!(writer.value(), "Hello");
         similar_asserts::assert_eq!(writer.style.indent, 2);
     }


### PR DESCRIPTION
- Reworked traversal of the AST to enable rules to be evaluated after the children (fixes #35 )
- Check for empty grouping when adding newlines e.g. functions (fixes #18 )